### PR TITLE
Fix CategorieTask service injection and update logic

### DIFF
--- a/Controllers/CategorieTaskController.cs
+++ b/Controllers/CategorieTaskController.cs
@@ -14,9 +14,10 @@ namespace Todo.Controllers
         private readonly AppDbContext _context;
         private readonly CategorieTaskService _categorieTaskService;
 
-        public CategorieTaskManagerController(AppDbContext context)
+        public CategorieTaskManagerController(AppDbContext context, CategorieTaskService categorieTaskService)
         {
             _context = context;
+            _categorieTaskService = categorieTaskService;
         }
 
         [Authorize]

--- a/Program.cs
+++ b/Program.cs
@@ -37,6 +37,7 @@ builder.Services.AddDbContext<AppDbContext>(options =>
 
 builder.Services.AddScoped<TaskManagerServices>();
 builder.Services.AddScoped<LoginService>();
+builder.Services.AddScoped<CategorieTaskService>();
 
 
 var key = Encoding.ASCII.GetBytes(Settings.Secret);

--- a/Services/CategorieTaskService.cs
+++ b/Services/CategorieTaskService.cs
@@ -51,11 +51,14 @@ namespace Todo.Services
         {
             try
             {
-                CategorieTaskEntity categorieToUpdate = new()
+                var categorieToUpdate = _context.CategorieTasks.FirstOrDefault(c => c.Id == model.Id);
+                if (categorieToUpdate == null)
                 {
-                    Name = model.Name,
-                    Description = model.Description
-                };
+                    return NotFound();
+                }
+
+                categorieToUpdate.Name = model.Name;
+                categorieToUpdate.Description = model.Description;
 
                 _context.CategorieTasks.Update(categorieToUpdate);
                 _context.SaveChanges();

--- a/Services/TaskManagerServices.cs
+++ b/Services/TaskManagerServices.cs
@@ -148,21 +148,21 @@ namespace Todo.Services
 
         public IActionResult EditTask (TaskModel model, int id)
         {
-            TaskEntity taskToEdit = context.Tasks.FirstOrDefault(x => x.Id == id);
+            var taskToEdit = context.Tasks.FirstOrDefault(x => x.Id == id);
 
-            if (taskToEdit == null) return new NotFoundResult();
-
-            taskToEdit = new TaskEntity()
+            if (taskToEdit == null)
             {
-                Title = model.Title,
-                Description = model.Description
-            };
+                return new NotFoundResult();
+            }
+
+            taskToEdit.Title = model.Title;
+            taskToEdit.Description = model.Description;
 
             context.Tasks.Update(taskToEdit);
             context.SaveChanges();
 
             return Ok(taskToEdit);
-        } 
+        }
         public IActionResult DeleteTask (int id)
         {
             TaskEntity taskToDelete = context.Tasks.FirstOrDefault(x => x.Id == id);


### PR DESCRIPTION
## Summary
- register `CategorieTaskService` in DI container
- inject `CategorieTaskService` into `CategorieTaskManagerController`
- fix category update to modify existing entity
- fix task edit logic to modify retrieved task

## Testing
- `dotnet test TodoTest.sln` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855b19e6dd8832787347dfad820618a